### PR TITLE
Add support for VS2015 and a bug fix

### DIFF
--- a/Posh-VsVars.psm1
+++ b/Posh-VsVars.psm1
@@ -202,7 +202,7 @@ function Set-VsVars
   if ($setVersion) { return }
 
   (Get-VsVars -Version $Version).GetEnumerator() |
-    ? { $_.Key -ne 'PROMPT' } |
+    ? { $_.Key -ne 'PROMPT' -and -not [string]::IsNullOrEmpty($_.Key)} |
     % {
       $name = $_.Key
       $path = "Env:$name"

--- a/Posh-VsVars.psm1
+++ b/Posh-VsVars.psm1
@@ -109,7 +109,7 @@ function Get-VsVars
   [CmdletBinding()]
   param(
     [string]
-    [ValidateSet('7.1', '8.0', '9.0', '10.0', '11.0', '12.0', 'latest')]
+    [ValidateSet('7.1', '8.0', '9.0', '10.0', '11.0', '12.0', '14.0', 'latest')]
     $Version = 'latest'
   )
 
@@ -188,7 +188,7 @@ function Set-VsVars
   [CmdletBinding()]
   param(
     [string]
-    [ValidateSet('8.0', '9.0', '10.0', '11.0', '12.0', 'latest')]
+    [ValidateSet('8.0', '9.0', '10.0', '11.0', '12.0', '14.0', 'latest')]
     $Version = 'latest'
   )
 


### PR DESCRIPTION
The latest visual studio has moved up to 14.0 so I've added that to the ValidatorSet. 

On my machine after calling the VsVars bat one or more variables were empty which caused exceptions in the module. I've added some validation to cope better with these null keys.

Any feedback and criticism is welcomed and thanks for putting this together I've been using it for quite a while.
Nym
